### PR TITLE
Fix timeline ordering and visibility controls

### DIFF
--- a/admin/collections.tsx
+++ b/admin/collections.tsx
@@ -321,6 +321,14 @@ const timelineConfig = (
         </p>
       ),
     },
+    {
+      header: "Visibility",
+      cell: (entry) => (
+        <Badge variant="outline" className="t-meta">
+          {entry.hide ? "Hidden" : "Visible"}
+        </Badge>
+      ),
+    },
     { header: "Period", meta: true, cell: (entry) => entry.date },
   ],
   fields: [
@@ -334,6 +342,12 @@ const timelineConfig = (
       hint: "Free text, as it should read on the page: “Sept. 2024 – Present”.",
     },
     { name: "description", label: "Summary", type: "textarea", hint: "What you were responsible for. Two or three sentences beats one long one." },
+    {
+      name: "hide",
+      label: "Hide from the public site",
+      type: "switch",
+      hint: "Keeps this entry in the admin without showing it to visitors.",
+    },
   ],
   toValues: (entry) => ({ ...entry }),
   toPayload: (fields) => ({
@@ -341,6 +355,7 @@ const timelineConfig = (
     company: fields.text("company"),
     date: fields.text("date"),
     description: fields.text("description"),
+    hide: fields.flag("hide"),
   }),
   create: async (payload, token, current) => {
     const item = payload as unknown as TimelineEntry;
@@ -362,6 +377,29 @@ const timelineConfig = (
       current.filter((_, index) => index !== Number(id)),
       token,
     ),
+  reorder: async (id, direction, token, current) => {
+    const from = Number(id);
+    const to = from + direction;
+    if (!Number.isInteger(from) || to < 0 || to >= current.length) {
+      return current;
+    }
+    const reordered = [...current];
+    const [moved] = reordered.splice(from, 1);
+    reordered.splice(to, 0, moved);
+    await replaceCollection(kind, reordered, token);
+    return reordered;
+  },
+  visibility: {
+    isHidden: (entry) => Boolean(entry.hide),
+    setHidden: async (id, hidden, token, current) => {
+      const index = Number(id);
+      const updated = current.map((entry, entryIndex) =>
+        entryIndex === index ? { ...entry, hide: hidden } : entry,
+      );
+      await replaceCollection(kind, updated, token);
+      return updated;
+    },
+  },
 });
 
 /**

--- a/admin/components/CollectionScreen.tsx
+++ b/admin/components/CollectionScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pencil, Plus, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, Pencil, Plus, Trash2 } from "lucide-react";
 import { useMemo, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
   Sheet,
   SheetContent,
@@ -85,6 +86,21 @@ export type CollectionConfig<T> = {
     current: T[],
   ) => Promise<{ item: T }>;
   remove: (id: string, token: string, current: T[]) => Promise<unknown>;
+  reorder?: (
+    id: string,
+    direction: -1 | 1,
+    token: string,
+    current: T[],
+  ) => Promise<T[]>;
+  visibility?: {
+    isHidden: (item: T) => boolean;
+    setHidden: (
+      id: string,
+      hidden: boolean,
+      token: string,
+      current: T[],
+    ) => Promise<T[]>;
+  };
   /** How a record identifies itself in a list and a delete confirmation. */
   identify: (item: T, index: number) => { id: string; label: string };
 };
@@ -126,6 +142,7 @@ export function CollectionScreen<T>({ config }: { config: CollectionConfig<T> })
   } | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [updatingRow, setUpdatingRow] = useState<string | null>(null);
 
   /** Identity is resolved against the loaded order before any sorting. */
   const rows = useMemo(
@@ -190,6 +207,34 @@ export function CollectionScreen<T>({ config }: { config: CollectionConfig<T> })
     }
   };
 
+  const reorder = async (id: string, direction: -1 | 1) => {
+    if (!token || !config.reorder) return;
+    setUpdatingRow(id);
+    try {
+      set(await config.reorder(id, direction, token, items));
+      toast.success("Order saved");
+    } catch (reorderError) {
+      toast.error((reorderError as Error)?.message ?? "Reorder failed");
+    } finally {
+      setUpdatingRow(null);
+    }
+  };
+
+  const setHidden = async (id: string, hidden: boolean) => {
+    if (!token || !config.visibility) return;
+    setUpdatingRow(id);
+    try {
+      set(await config.visibility.setHidden(id, hidden, token, items));
+      toast.success(hidden ? `${config.noun} hidden` : `${config.noun} visible`);
+    } catch (visibilityError) {
+      toast.error(
+        (visibilityError as Error)?.message ?? "Visibility update failed",
+      );
+    } finally {
+      setUpdatingRow(null);
+    }
+  };
+
   return (
     <>
       <PageHeader
@@ -250,7 +295,12 @@ export function CollectionScreen<T>({ config }: { config: CollectionConfig<T> })
                     {column.header}
                   </TableHead>
                 ))}
-                <TableHead className="w-20 text-right">
+                {config.visibility ? (
+                  <TableHead className="t-eyebrow w-24 text-center text-ink-faint">
+                    Visible
+                  </TableHead>
+                ) : null}
+                <TableHead className="w-32 text-right">
                   <span className="sr-only">Actions</span>
                 </TableHead>
               </TableRow>
@@ -270,8 +320,45 @@ export function CollectionScreen<T>({ config }: { config: CollectionConfig<T> })
                         {column.cell(item)}
                       </TableCell>
                     ))}
+                    {config.visibility ? (
+                      <TableCell className="text-center">
+                        <Switch
+                          checked={!config.visibility.isHidden(item)}
+                          disabled={updatingRow !== null}
+                          aria-label={`Show ${label} on the public site`}
+                          onCheckedChange={(checked) =>
+                            void setHidden(id, !checked)
+                          }
+                        />
+                      </TableCell>
+                    ) : null}
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-0.5">
+                        {config.reorder ? (
+                          <>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              aria-label={`Move ${label} up`}
+                              disabled={updatingRow !== null || Number(id) === 0}
+                              onClick={() => void reorder(id, -1)}
+                            >
+                              <ChevronUp />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              aria-label={`Move ${label} down`}
+                              disabled={
+                                updatingRow !== null ||
+                                Number(id) === items.length - 1
+                              }
+                              onClick={() => void reorder(id, 1)}
+                            >
+                              <ChevronDown />
+                            </Button>
+                          </>
+                        ) : null}
                         <Button
                           variant="ghost"
                           size="icon"

--- a/app/admin/(protected)/experiences/page.tsx
+++ b/app/admin/(protected)/experiences/page.tsx
@@ -1,7 +1,7 @@
 import { CollectionScreen } from "@/admin/components/CollectionScreen";
 import { experiencesConfig } from "@/admin/collections";
 
-export const metadata = { title: "Admin · Uexperiences" };
+export const metadata = { title: "Admin · Experiences" };
 
 export default function Page() {
   return <CollectionScreen config={experiencesConfig} />;

--- a/app/admin/(protected)/notes/page.tsx
+++ b/app/admin/(protected)/notes/page.tsx
@@ -1,7 +1,7 @@
 import { CollectionScreen } from "@/admin/components/CollectionScreen";
 import { notesConfig } from "@/admin/collections";
 
-export const metadata = { title: "Admin · Unotes" };
+export const metadata = { title: "Admin · Notes" };
 
 export default function Page() {
   return <CollectionScreen config={notesConfig} />;

--- a/app/admin/(protected)/projects/page.tsx
+++ b/app/admin/(protected)/projects/page.tsx
@@ -1,7 +1,7 @@
 import { CollectionScreen } from "@/admin/components/CollectionScreen";
 import { projectsConfig } from "@/admin/collections";
 
-export const metadata = { title: "Admin · Uprojects" };
+export const metadata = { title: "Admin · Projects" };
 
 export default function Page() {
   return <CollectionScreen config={projectsConfig} />;

--- a/app/admin/(protected)/studies/page.tsx
+++ b/app/admin/(protected)/studies/page.tsx
@@ -1,7 +1,7 @@
 import { CollectionScreen } from "@/admin/components/CollectionScreen";
 import { studiesConfig } from "@/admin/collections";
 
-export const metadata = { title: "Admin · Ustudies" };
+export const metadata = { title: "Admin · Studies" };
 
 export default function Page() {
   return <CollectionScreen config={studiesConfig} />;

--- a/components/home/Path.tsx
+++ b/components/home/Path.tsx
@@ -93,6 +93,9 @@ export function Path({
   experiences: TimelineEntry[];
   studies: TimelineEntry[];
 }) {
+  const visibleExperiences = experiences.filter((entry) => !entry.hide);
+  const visibleStudies = studies.filter((entry) => !entry.hide);
+
   return (
     <Page as="div" data-ink="azure">
       <Section id="path" labelledBy="path-title">
@@ -119,13 +122,13 @@ export function Path({
             heading="Experience"
             icon={<Briefcase />}
             ink="azure"
-            entries={experiences}
+            entries={visibleExperiences}
           />
           <Group
             heading="Studies"
             icon={<GraduationCap />}
             ink="turquoise"
-            entries={studies}
+            entries={visibleStudies}
           />
         </div>
       </Section>

--- a/lib/ai/tools/selfTools.ts
+++ b/lib/ai/tools/selfTools.ts
@@ -192,10 +192,16 @@ export const buildSelfTools = () => {
     handler: async () => {
       const [experiences, studies] = await Promise.all([
         getExperiencesCollection().then((collection) =>
-          collection.find({}, { projection: { _id: 0 } }).toArray(),
+          collection
+            .find({ hide: { $ne: true } }, { projection: { _id: 0 } })
+            .sort({ order: 1, date: -1, _id: 1 })
+            .toArray(),
         ),
         getStudiesCollection().then((collection) =>
-          collection.find({}, { projection: { _id: 0 } }).toArray(),
+          collection
+            .find({ hide: { $ne: true } }, { projection: { _id: 0 } })
+            .sort({ order: 1, date: -1, _id: 1 })
+            .toArray(),
         ),
       ]);
 

--- a/migrations/003-timeline-visibility.mjs
+++ b/migrations/003-timeline-visibility.mjs
@@ -1,0 +1,28 @@
+/**
+ * Existing experiences and studies predate the admin visibility control.
+ *
+ * Missing `hide` means visible at runtime, but making that default explicit in
+ * the database gives every record the same shape and keeps future tooling
+ * predictable. Existing explicit values are deliberately preserved.
+ */
+export const description = "Initialize missing timeline visibility flags";
+
+export async function up(db, { apply, log, note }) {
+  for (const name of ["experiences", "studies"]) {
+    const collection = db.collection(name);
+    const count = await collection.countDocuments({ hide: { $exists: false } });
+
+    if (count === 0) {
+      note("all " + name + " already have a `hide` flag");
+      continue;
+    }
+
+    log("set `hide: false` on " + count + " " + name + " without the flag");
+    if (apply) {
+      await collection.updateMany(
+        { hide: { $exists: false } },
+        { $set: { hide: false } },
+      );
+    }
+  }
+}

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -9,6 +9,7 @@ migrations/
   lib.mjs              connection + shared helpers
   001-baseline.mjs      loads the versioned snapshot into an empty database
   002-notes-rename.mjs  articles -> notes
+  003-timeline-visibility.mjs  initializes missing experience and study hide flags
   baseline/
     data.json          every content document, _id stripped
     schema.json        every field path, its types, how many documents have it

--- a/types.ts
+++ b/types.ts
@@ -68,6 +68,7 @@ export interface TimelineEntry {
   company: string;
   date: string;
   description: string;
+  hide?: boolean;
 }
 
 // --- Interfaces (assuming these are defined elsewhere or keep them here) ---


### PR DESCRIPTION
## Summary

- add persistent move-up/move-down ordering controls for experiences and studies in the admin
- add visibility toggles that keep hidden timeline entries editable without deleting them
- exclude hidden experiences and studies from the public home page and the site assistant
- add migration `003-timeline-visibility` to initialize missing `hide` flags to `false`
- fix the admin experiences page title typo

## Root cause

Timeline entries already had a stored `order`, but the shared admin collection screen did not expose any reordering action. The timeline model also had no admin visibility control, so removing an entry from the public site required deleting it.

## Impact

Admins can now reorder and temporarily hide experiences or studies. Existing entries remain visible because the migration only sets missing flags to `hide: false`; explicit values are preserved.

## Validation

- `npm run lint`
- `npm run build`
- migration syntax check with `node --check`
- isolated migration dry-run/apply behavior test for both collections

## Deployment note

Run `npm run migrate` to review the pending migration, then `npm run migrate -- --apply` after deployment.