### PR TITLE
Bound Open Graph image memory usage

### DIFF
--- a/app/(site)/notes/[slug]/opengraph-image.tsx
+++ b/app/(site)/notes/[slug]/opengraph-image.tsx
@@ -11,7 +11,9 @@ export const alt = "Note by Mathis Lambert";
 export const size = SHARE_IMAGE_SIZE;
 export const contentType = SHARE_IMAGE_CONTENT_TYPE;
 
-export const dynamic = "force-dynamic";
+// Content changes are uncommon; let Next reuse generated images instead of
+// invoking Satori and Sharp for every crawler request.
+export const revalidate = 3600;
 
 export default async function NoteShareImage({
   params,

--- a/app/(site)/projects/[slug]/opengraph-image.tsx
+++ b/app/(site)/projects/[slug]/opengraph-image.tsx
@@ -11,7 +11,9 @@ export const alt = "Project by Mathis Lambert";
 export const size = SHARE_IMAGE_SIZE;
 export const contentType = SHARE_IMAGE_CONTENT_TYPE;
 
-export const dynamic = "force-dynamic";
+// Content changes are uncommon; let Next reuse generated images instead of
+// invoking Satori and Sharp for every crawler request.
+export const revalidate = 3600;
 
 export default async function ProjectShareImage({
   params,

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -5,6 +5,8 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: production
+      NODE_OPTIONS: --max-old-space-size=512
+      MALLOC_ARENA_MAX: 2
       HOSTNAME: 0.0.0.0
       PORT: 3000
       NEXT_PUBLIC_MAPS_PUBLIC_KEY: ${NEXT_PUBLIC_MAPS_PUBLIC_KEY}
@@ -31,6 +33,23 @@ services:
       MEDIA_S3_ACCESS_KEY_ID: ${MEDIA_S3_ACCESS_KEY_ID}
       MEDIA_S3_SECRET_ACCESS_KEY: ${MEDIA_S3_SECRET_ACCESS_KEY}
       MEDIA_PUBLIC_BASE_URL: ${MEDIA_PUBLIC_BASE_URL}
+    init: true
+    mem_limit: 1g
+    mem_reservation: 256m
+    cpus: "1.00"
+    pids_limit: 128
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3000/').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=proxy"

--- a/lib/og/share-image.tsx
+++ b/lib/og/share-image.tsx
@@ -15,9 +15,29 @@ import { loadOgFonts } from "@/lib/og/fonts";
 export const SHARE_IMAGE_SIZE = { width: 1200, height: 630 };
 export const SHARE_IMAGE_CONTENT_TYPE = "image/png";
 
+const SHARE_IMAGE_CACHE_CONTROL =
+  "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800";
+const MAX_SOURCE_BYTES = 12 * 1024 * 1024;
+const MAX_SOURCE_PIXELS = 40_000_000;
+const PHOTO_CACHE_TTL_MS = 60 * 60 * 1000;
+const PHOTO_CACHE_MAX_ENTRIES = 12;
+
 const { width, height } = SHARE_IMAGE_SIZE;
 
 const RULE_ON_DARK = "rgba(255, 255, 255, 0.28)";
+
+type PhotoCacheEntry = {
+  expiresAt: number;
+  value: Promise<string | undefined>;
+};
+
+const photoCache = new Map<string, PhotoCacheEntry>();
+
+// libvips otherwise keeps a sizeable process-wide cache and uses one worker
+// per CPU. OG images are latency-insensitive and generated infrequently, so a
+// small cache and a single worker give the server a predictable memory ceiling.
+sharp.cache({ memory: 16, files: 0, items: PHOTO_CACHE_MAX_ENTRIES });
+sharp.concurrency(1);
 
 export type ShareImageInput = {
   kind: CoverKind;
@@ -36,18 +56,68 @@ export type ShareImageInput = {
  * JPEG here, cropped to the frame. Undefined on any failure, so an unreachable
  * CDN costs the photograph rather than the whole preview.
  */
-const loadPhoto = async (cover: string, base: string): Promise<string | undefined> => {
+const decodePhoto = async (url: URL): Promise<string | undefined> => {
   try {
-    const response = await fetch(new URL(cover, base), { signal: AbortSignal.timeout(5000) });
+    const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
     if (!response.ok) return undefined;
-    const jpeg = await sharp(Buffer.from(await response.arrayBuffer()))
-      .resize(width, height, { fit: "cover" })
-      .jpeg({ quality: 82 })
-      .toBuffer();
-    return `data:image/jpeg;base64,${jpeg.toString("base64")}`;
+
+    const declaredSize = Number(response.headers.get("content-length"));
+    if (Number.isFinite(declaredSize) && declaredSize > MAX_SOURCE_BYTES) return undefined;
+
+    const source = Buffer.from(await response.arrayBuffer());
+    if (source.byteLength > MAX_SOURCE_BYTES) return undefined;
+
+    const pipeline = sharp(source, {
+      failOn: "error",
+      limitInputPixels: MAX_SOURCE_PIXELS,
+      sequentialRead: true,
+    });
+
+    try {
+      const jpeg = await pipeline
+        .rotate()
+        .resize(width, height, { fit: "cover", withoutEnlargement: true })
+        .jpeg({ quality: 82 })
+        .toBuffer();
+      return `data:image/jpeg;base64,${jpeg.toString("base64")}`;
+    } finally {
+      pipeline.destroy();
+    }
   } catch {
     return undefined;
   }
+};
+
+const loadPhoto = async (cover: string, base: string): Promise<string | undefined> => {
+  let url: URL;
+  try {
+    url = new URL(cover, base);
+  } catch {
+    return undefined;
+  }
+
+  const key = url.toString();
+  const now = Date.now();
+  const cached = photoCache.get(key);
+  if (cached && cached.expiresAt > now) {
+    photoCache.delete(key);
+    photoCache.set(key, cached);
+    return cached.value;
+  }
+  if (cached) photoCache.delete(key);
+
+  const value = decodePhoto(url);
+  photoCache.set(key, { expiresAt: now + PHOTO_CACHE_TTL_MS, value });
+
+  while (photoCache.size > PHOTO_CACHE_MAX_ENTRIES) {
+    const oldest = photoCache.keys().next().value;
+    if (oldest === undefined) break;
+    photoCache.delete(oldest);
+  }
+
+  const decoded = await value;
+  if (!decoded) photoCache.delete(key);
+  return decoded;
 };
 
 export async function renderShareImage(
@@ -78,7 +148,11 @@ export async function renderShareImage(
         seed={seed}
       />
     ),
-    { ...SHARE_IMAGE_SIZE, fonts },
+    {
+      ...SHARE_IMAGE_SIZE,
+      fonts,
+      headers: { "Cache-Control": SHARE_IMAGE_CACHE_CONTROL },
+    },
   );
 }
 


### PR DESCRIPTION
## Contexte

Le redéploiement de la v3.1.3 a fait passer le conteneur d'environ 123 MiB à plus de 590 MiB de mémoire résidente. La hausse coïncide avec l'ajout du traitement des photos Open Graph par Sharp/libvips : chaque requête de crawler régénérait dynamiquement l'image et libvips conservait un cache natif important.

## Correctif

- met en cache les images Open Graph côté Next/CDN au lieu de les recalculer à chaque requête ;
- borne le cache libvips à 16 MiB et limite Sharp à un worker ;
- déduplique et borne à 12 entrées les transformations de photos en mémoire ;
- refuse les sources anormalement lourdes (12 MiB / 40 MP), ajoute un timeout et libère explicitement le pipeline ;
- redimensionne les sources à 1200×630 sans agrandissement ;
- ajoute des limites de production au conteneur (1 Gio, 1 CPU, 128 PID, heap Node 512 MiB, arènes malloc limitées) ;
- ajoute un init minimal et un healthcheck HTTP.

## Impact attendu

La génération d'une preview reste fonctionnelle, mais son coût n'est plus répété à chaque passage de crawler. La mémoire native de Sharp est plafonnée, les traitements concurrents sont limités et Docker dispose d'un dernier garde-fou contre une croissance non bornée.

## Validation

- `npm run lint`
- `npm test`
- `npm run build` (Next.js + TypeScript + génération statique)
- `docker compose -f compose.prod.yaml config -q`
- `git diff --check`
