### PR TITLE
Preserve LaTeX in editorial content

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1490,12 +1490,50 @@
   color: var(--ink);
 }
 
+.prose-paper .katex-display {
+  max-width: 100%;
+  margin-block: 1.75rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-block: 0.25rem;
+}
+
+.prose-paper .katex-display > .katex {
+  white-space: nowrap;
+}
+
 /* ── Editorial atelier ───────────────────────────────────────────────── */
 
 .editorial-canvas .ProseMirror {
   min-height: 52vh;
   caret-color: var(--brand);
 }
+
+.editorial-math-block {
+  display: grid;
+  gap: 0.75rem;
+  margin-block: 1.5rem;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper-lift);
+}
+
+.editorial-math-block textarea,
+.editorial-math-inline input {
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-mono), monospace;
+  font-size: 0.8rem;
+  outline: none;
+}
+
+.editorial-math-block textarea { width: 100%; resize: vertical; padding: 0.65rem 0.75rem; }
+.editorial-math-inline { display: inline-flex; align-items: center; gap: 0.45rem; padding: 0.15rem 0.3rem; border-radius: var(--r-2); background: var(--paper-lift); }
+.editorial-math-inline input { width: 8rem; padding: 0.25rem 0.4rem; }
+.editorial-math-preview { max-width: 100%; overflow-x: auto; }
 
 .editorial-canvas .ProseMirror > *:first-child {
   margin-top: 0;

--- a/components/admin/editorial/RichMarkdownEditor.tsx
+++ b/components/admin/editorial/RichMarkdownEditor.tsx
@@ -27,6 +27,7 @@ import { toast } from "sonner";
 
 import { uploadMediaAsset } from "@/api/media";
 import { EditorialCodeBlock } from "@/components/admin/editorial/extensions/EditorialCodeBlock";
+import { EditorialMathBlock, EditorialMathInline } from "@/components/admin/editorial/extensions/EditorialMath";
 import { LinkBubbleMenu } from "@/components/admin/editorial/LinkBubbleMenu";
 import { MediaLibraryDialog } from "@/components/admin/editorial/MediaLibraryDialog";
 import { SlashCommandMenu } from "@/components/admin/editorial/SlashCommandMenu";
@@ -51,6 +52,8 @@ export function RichMarkdownEditor({
         link: { openOnClick: false },
       }),
       EditorialCodeBlock,
+      EditorialMathBlock,
+      EditorialMathInline,
       ImageExtension.configure({ allowBase64: false }),
       Placeholder.configure({ placeholder: "Start writing… Type / for commands" }),
       Markdown,

--- a/components/admin/editorial/extensions/EditorialMath.tsx
+++ b/components/admin/editorial/extensions/EditorialMath.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { mergeAttributes, Node, type NodeViewProps } from "@tiptap/core";
+import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import katex from "katex";
+import { useMemo } from "react";
+import { mathBlockTokenizer, mathInlineTokenizer, MATH_BLOCK_TOKEN, MATH_INLINE_TOKEN } from "@/lib/editorial/math-markdown";
+
+function MathNodeView({ node, updateAttributes }: NodeViewProps) {
+  const latex = String(node.attrs.latex ?? "");
+  const displayMode = node.type.name === MATH_BLOCK_TOKEN;
+  const html = useMemo(() => katex.renderToString(latex, { displayMode, throwOnError: false, strict: "warn" }), [displayMode, latex]);
+  return (
+    <NodeViewWrapper as={displayMode ? "div" : "span"} className={displayMode ? "editorial-math-block" : "editorial-math-inline"}>
+      <span className="editorial-math-preview" contentEditable={false} dangerouslySetInnerHTML={{ __html: html }} />
+      {displayMode ? (
+        <textarea value={latex} onChange={(event) => updateAttributes({ latex: event.target.value })} aria-label="Block LaTeX" rows={Math.max(2, latex.split("\n").length)} spellCheck={false} />
+      ) : (
+        <input value={latex} onChange={(event) => updateAttributes({ latex: event.target.value })} aria-label="Inline LaTeX" spellCheck={false} />
+      )}
+    </NodeViewWrapper>
+  );
+}
+
+const mathAttributes = { latex: { default: "" } };
+
+export const EditorialMathBlock = Node.create({
+  name: MATH_BLOCK_TOKEN,
+  group: "block",
+  atom: true,
+  isolating: true,
+  addAttributes: () => mathAttributes,
+  parseHTML: () => [{ tag: "div[data-math-block]" }],
+  renderHTML: ({ HTMLAttributes }) => ["div", mergeAttributes(HTMLAttributes, { "data-math-block": "" })],
+  markdownTokenName: MATH_BLOCK_TOKEN,
+  markdownTokenizer: mathBlockTokenizer,
+  parseMarkdown: (token, helpers) => helpers.createNode(MATH_BLOCK_TOKEN, token.attributes),
+  renderMarkdown: (node) => `$$\n${node.attrs?.latex ?? ""}\n$$`,
+  addNodeView: () => ReactNodeViewRenderer(MathNodeView),
+});
+
+export const EditorialMathInline = Node.create({
+  name: MATH_INLINE_TOKEN,
+  group: "inline",
+  inline: true,
+  atom: true,
+  addAttributes: () => mathAttributes,
+  parseHTML: () => [{ tag: "span[data-math-inline]" }],
+  renderHTML: ({ HTMLAttributes }) => ["span", mergeAttributes(HTMLAttributes, { "data-math-inline": "" })],
+  markdownTokenName: MATH_INLINE_TOKEN,
+  markdownTokenizer: mathInlineTokenizer,
+  parseMarkdown: (token, helpers) => helpers.createNode(MATH_INLINE_TOKEN, token.attributes),
+  renderMarkdown: (node) => `$${node.attrs?.latex ?? ""}$`,
+  addNodeView: () => ReactNodeViewRenderer(MathNodeView),
+});

--- a/lib/editorial/math-markdown.ts
+++ b/lib/editorial/math-markdown.ts
@@ -1,0 +1,26 @@
+import type { MarkdownToken, MarkdownTokenizer } from "@tiptap/core";
+
+export const MATH_BLOCK_TOKEN = "mathBlock";
+export const MATH_INLINE_TOKEN = "mathInline";
+
+export const mathBlockTokenizer: MarkdownTokenizer = {
+  name: MATH_BLOCK_TOKEN,
+  level: "block",
+  start: (source) => source.search(/^\s*\$\$/m),
+  tokenize(source) {
+    const match = /^\s*\$\$[ \t]*\n?([\s\S]*?)\n?[ \t]*\$\$(?:\n|$)/.exec(source);
+    if (!match) return;
+    return { type: MATH_BLOCK_TOKEN, raw: match[0], attributes: { latex: match[1].trim() } } as MarkdownToken;
+  },
+};
+
+export const mathInlineTokenizer: MarkdownTokenizer = {
+  name: MATH_INLINE_TOKEN,
+  level: "inline",
+  start: (source) => source.search(/(?<!\\)\$(?!\$)/),
+  tokenize(source) {
+    const match = /^\$(?!\$)((?:\\.|[^$\n\\])+)\$/.exec(source);
+    if (!match) return;
+    return { type: MATH_INLINE_TOKEN, raw: match[0], attributes: { latex: match[1] } } as MarkdownToken;
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1100.0",
         "@base-ui/react": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node --test tests/migrations/*.test.mjs",
+    "test": "node --experimental-strip-types --test tests/**/*.test.mjs",
     "lint": "eslint",
     "check:api-analytics": "node scripts/check-api-analytics.mjs",
     "seed:dev": "node --env-file=.env scripts/seed-dev.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/tests/editorial/math-markdown.test.mjs
+++ b/tests/editorial/math-markdown.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  mathBlockTokenizer,
+  mathInlineTokenizer,
+} from "../../lib/editorial/math-markdown.ts";
+
+test("block math preserves commands, subscripts and line breaks", () => {
+  const source = String.raw`$$
+\min_{u_0,\ldots,u_{N-1}}
+\sum_{k=0}^{N-1}
+\left(\lVert x_k-x_k^{ref}\rVert_Q^2-\lVert u_k\rVert_R^2\right)
+$$
+`;
+  const token = mathBlockTokenizer.tokenize(source, [], {});
+
+  assert.equal(
+    token?.attributes?.latex,
+    String.raw`\min_{u_0,\ldots,u_{N-1}}
+\sum_{k=0}^{N-1}
+\left(\lVert x_k-x_k^{ref}\rVert_Q^2-\lVert u_k\rVert_R^2\right)`,
+  );
+});
+
+test("inline math preserves subscripts", () => {
+  const token = mathInlineTokenizer.tokenize(String.raw`$x_k^{ref}$ rest`, [], {});
+  assert.equal(token?.attributes?.latex, String.raw`x_k^{ref}`);
+  assert.equal(token?.raw, String.raw`$x_k^{ref}$`);
+});


### PR DESCRIPTION
## Summary

- preserve inline and display LaTeX as dedicated Tiptap nodes
- render a live KaTeX preview in the editorial workspace
- make wide display equations scroll safely on small screens
- add regression coverage for commands, subscripts, superscripts and multiline formulas

## Root cause

Tiptap treated dollar-delimited formulas as ordinary Markdown text. Its serializer consequently consumed LaTeX backslashes as Markdown escapes before Notes and Projects reached KaTeX.

## Validation

- npm run lint
- npm test
- npm run build
- git diff --check