### PR TITLE
Harden image processing and math input

### DIFF
--- a/components/admin/editorial/RichMarkdownEditor.tsx
+++ b/components/admin/editorial/RichMarkdownEditor.tsx
@@ -20,6 +20,7 @@ import {
   Minus,
   Quote,
   Redo2,
+  Sigma,
   Undo2,
 } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -165,6 +166,8 @@ export function RichMarkdownEditor({
         {tool("Numbered list", <ListOrdered />, editor.isActive("orderedList"), () => editor.chain().focus().toggleOrderedList().run())}
         {tool("Quote", <Quote />, editor.isActive("blockquote"), () => editor.chain().focus().toggleBlockquote().run())}
         {tool("Code block", <Code2 />, editor.isActive("codeBlock"), () => editor.chain().focus().toggleCodeBlock().run())}
+        {tool("Inline formula", <Sigma />, editor.isActive("mathInline"), () => editor.chain().focus().insertContent({ type: "mathInline", attrs: { latex: "x_k" } }).run())}
+        {tool("Display formula", <Sigma className="size-5" />, editor.isActive("mathBlock"), () => editor.chain().focus().insertContent({ type: "mathBlock", attrs: { latex: String.raw`\sum_{k=0}^{N-1} x_k` } }).run())}
         {tool("Divider", <Minus />, false, () => editor.chain().focus().setHorizontalRule().run())}
         {tool("Link", <Link2 />, editor.isActive("link"), openLinkMenu)}
         {tool(uploading ? "Uploading image" : "Image", uploading ? <Loader2 className="animate-spin" /> : <ImagePlus />, false, () => setMediaOpen(true))}

--- a/components/admin/editorial/extensions/EditorialMath.tsx
+++ b/components/admin/editorial/extensions/EditorialMath.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { mergeAttributes, Node, type NodeViewProps } from "@tiptap/core";
+import { InputRule, mergeAttributes, Node, nodePasteRule, type NodeViewProps } from "@tiptap/core";
+import type { NodeType } from "@tiptap/pm/model";
 import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 import katex from "katex";
 import { useMemo } from "react";
@@ -23,6 +24,26 @@ function MathNodeView({ node, updateAttributes }: NodeViewProps) {
 }
 
 const mathAttributes = { latex: { default: "" } };
+const inlineMathInput = /(?<!\\)(?<!\$)\$((?:\\.|[^$\n\\])+)\$$/;
+const blockMathInput = /^\$\$([^$\n]+)\$\$$/;
+const inlineMathPaste = /(?<!\\)(?<!\$)\$((?:\\.|[^$\n\\])+)\$(?!\$)/g;
+const blockMathPaste = /\$\$\s*([\s\S]+?)\s*\$\$/g;
+
+const mathInputRule = (type: NodeType, find: RegExp) =>
+  new InputRule({
+    find: (text) => {
+      const match = find.exec(text);
+      if (!match) return null;
+      return { text: match[0], index: match.index, data: { latex: match[1] } };
+    },
+    handler: ({ state, range, match }) => {
+      state.tr.replaceWith(
+        range.from,
+        range.to,
+        type.create({ latex: String(match.data?.latex ?? "") }),
+      );
+    },
+  });
 
 export const EditorialMathBlock = Node.create({
   name: MATH_BLOCK_TOKEN,
@@ -36,6 +57,18 @@ export const EditorialMathBlock = Node.create({
   markdownTokenizer: mathBlockTokenizer,
   parseMarkdown: (token, helpers) => helpers.createNode(MATH_BLOCK_TOKEN, token.attributes),
   renderMarkdown: (node) => `$$\n${node.attrs?.latex ?? ""}\n$$`,
+  addInputRules() {
+    return [mathInputRule(this.type, blockMathInput)];
+  },
+  addPasteRules() {
+    return [
+      nodePasteRule({
+        find: blockMathPaste,
+        type: this.type,
+        getAttributes: (match) => ({ latex: match[1].trim() }),
+      }),
+    ];
+  },
   addNodeView: () => ReactNodeViewRenderer(MathNodeView),
 });
 
@@ -51,5 +84,17 @@ export const EditorialMathInline = Node.create({
   markdownTokenizer: mathInlineTokenizer,
   parseMarkdown: (token, helpers) => helpers.createNode(MATH_INLINE_TOKEN, token.attributes),
   renderMarkdown: (node) => `$${node.attrs?.latex ?? ""}$`,
+  addInputRules() {
+    return [mathInputRule(this.type, inlineMathInput)];
+  },
+  addPasteRules() {
+    return [
+      nodePasteRule({
+        find: inlineMathPaste,
+        type: this.type,
+        getAttributes: (match) => ({ latex: match[1] }),
+      }),
+    ];
+  },
   addNodeView: () => ReactNodeViewRenderer(MathNodeView),
 });

--- a/lib/og/bounded-processing.ts
+++ b/lib/og/bounded-processing.ts
@@ -1,0 +1,57 @@
+export function createConcurrencyLimiter(maxConcurrent: number) {
+  let active = 0;
+  const waiting: Array<() => void> = [];
+
+  const acquire = async () => {
+    if (active < maxConcurrent) {
+      active += 1;
+      return;
+    }
+    await new Promise<void>((resolve) => waiting.push(resolve));
+  };
+
+  const release = () => {
+    const next = waiting.shift();
+    if (next) next();
+    else active -= 1;
+  };
+
+  return async <T>(work: () => Promise<T>): Promise<T> => {
+    await acquire();
+    try {
+      return await work();
+    } finally {
+      release();
+    }
+  };
+}
+
+export async function readBoundedResponse(
+  response: Response,
+  maxBytes: number,
+): Promise<Buffer> {
+  const declaredSize = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredSize) && declaredSize > maxBytes) {
+    throw new RangeError("Response exceeds byte limit");
+  }
+  if (!response.body) return Buffer.alloc(0);
+
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel("Response exceeds byte limit");
+        throw new RangeError("Response exceeds byte limit");
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, total);
+}

--- a/lib/og/share-image.tsx
+++ b/lib/og/share-image.tsx
@@ -5,6 +5,7 @@ import sharp from "sharp";
 
 import { EditorialCover } from "@/components/content/EditorialCover";
 import { COVER_PALETTE, clampText, coverInk, type CoverKind } from "@/lib/content/cover";
+import { createConcurrencyLimiter, readBoundedResponse } from "@/lib/og/bounded-processing";
 import { loadOgFonts } from "@/lib/og/fonts";
 
 /**
@@ -21,6 +22,7 @@ const MAX_SOURCE_BYTES = 12 * 1024 * 1024;
 const MAX_SOURCE_PIXELS = 40_000_000;
 const PHOTO_CACHE_TTL_MS = 60 * 60 * 1000;
 const PHOTO_CACHE_MAX_ENTRIES = 12;
+const MAX_CONCURRENT_PHOTO_DECODES = 2;
 
 const { width, height } = SHARE_IMAGE_SIZE;
 
@@ -32,6 +34,7 @@ type PhotoCacheEntry = {
 };
 
 const photoCache = new Map<string, PhotoCacheEntry>();
+const limitPhotoDecode = createConcurrencyLimiter(MAX_CONCURRENT_PHOTO_DECODES);
 
 // libvips otherwise keeps a sizeable process-wide cache and uses one worker
 // per CPU. OG images are latency-insensitive and generated infrequently, so a
@@ -57,15 +60,12 @@ export type ShareImageInput = {
  * CDN costs the photograph rather than the whole preview.
  */
 const decodePhoto = async (url: URL): Promise<string | undefined> => {
-  try {
+  return limitPhotoDecode(async () => {
+    try {
     const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
     if (!response.ok) return undefined;
 
-    const declaredSize = Number(response.headers.get("content-length"));
-    if (Number.isFinite(declaredSize) && declaredSize > MAX_SOURCE_BYTES) return undefined;
-
-    const source = Buffer.from(await response.arrayBuffer());
-    if (source.byteLength > MAX_SOURCE_BYTES) return undefined;
+    const source = await readBoundedResponse(response, MAX_SOURCE_BYTES);
 
     const pipeline = sharp(source, {
       failOn: "error",
@@ -83,9 +83,10 @@ const decodePhoto = async (url: URL): Promise<string | undefined> => {
     } finally {
       pipeline.destroy();
     }
-  } catch {
-    return undefined;
-  }
+    } catch {
+      return undefined;
+    }
+  });
 };
 
 const loadPhoto = async (cover: string, base: string): Promise<string | undefined> => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1100.0",
         "@base-ui/react": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/tests/og/bounded-processing.test.mjs
+++ b/tests/og/bounded-processing.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createConcurrencyLimiter,
+  readBoundedResponse,
+} from "../../lib/og/bounded-processing.ts";
+
+test("response reading aborts once the streaming byte limit is exceeded", async () => {
+  let cancelled = false;
+  const body = new ReadableStream({
+    pull(controller) {
+      controller.enqueue(new Uint8Array(6));
+      controller.enqueue(new Uint8Array(6));
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+
+  await assert.rejects(
+    readBoundedResponse(new Response(body), 10),
+    /exceeds byte limit/,
+  );
+  assert.equal(cancelled, true);
+});
+
+test("concurrency limiter never starts more than two jobs", async () => {
+  const limit = createConcurrencyLimiter(2);
+  let active = 0;
+  let peak = 0;
+  const jobs = Array.from({ length: 8 }, () =>
+    limit(async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+    }),
+  );
+
+  await Promise.all(jobs);
+  assert.equal(peak, 2);
+});


### PR DESCRIPTION
## Summary

Addresses all actionable Codex review feedback from #16 and #17.

- cap active Open Graph photo decodes with a process-wide semaphore
- stream remote image bodies and cancel as soon as the 12 MiB limit is crossed
- convert typed and pasted dollar-delimited formulas into Tiptap math nodes
- add explicit inline and display formula insertion controls
- add regression tests for streaming limits and peak concurrency
- bump the release version to 3.1.5

## Validation

- npm test (6 passing)
- npm run lint
- npm run build
- git diff --check